### PR TITLE
Add a basic ELT simulation xplat profiler

### DIFF
--- a/ProfilingAPI/ReJITEnterLeaveHooks/CComPtr.h
+++ b/ProfilingAPI/ReJITEnterLeaveHooks/CComPtr.h
@@ -1,0 +1,81 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma once
+
+template<class TInterface>
+class CComPtr
+{
+private:
+    TInterface* pointer;
+public:
+    CComPtr(const CComPtr&) = delete; // Copy constructor
+    CComPtr& operator= (const CComPtr&) = delete; // Copy assignment
+    CComPtr(CComPtr&&) = delete; // Move constructor
+    CComPtr& operator= (CComPtr&&) = delete; // Move assignment
+
+    void* operator new(std::size_t) = delete;
+    void* operator new[](std::size_t) = delete;
+
+    void operator delete(void *ptr) = delete;
+    void operator delete[](void *ptr) = delete;
+
+    CComPtr()
+    {
+        this->pointer = nullptr;
+    }
+
+    ~CComPtr()
+    {
+        if (this->pointer)
+        {
+            this->pointer->Release();
+            this->pointer = nullptr;
+        }
+    }
+
+    operator TInterface*()
+    {
+        return this->pointer;
+    }
+
+    operator TInterface*() const
+    {
+        return this->pointer;
+    }
+
+    TInterface& operator *()
+    {
+        return *this->pointer;
+    }
+
+    TInterface& operator *() const
+    {
+        return *this->pointer;
+    }
+
+    TInterface** operator&()
+    {
+        return &this->pointer;
+    }
+
+    TInterface** operator&() const
+    {
+        return &this->pointer;
+    }
+
+    TInterface* operator->()
+    {
+        return this->pointer;
+    }
+
+    TInterface* operator->() const
+    {
+        return this->pointer;
+    }
+
+    void Release()
+    {
+        this->~CComPtr();
+    }
+};

--- a/ProfilingAPI/ReJITEnterLeaveHooks/ClassFactory.cpp
+++ b/ProfilingAPI/ReJITEnterLeaveHooks/ClassFactory.cpp
@@ -1,0 +1,64 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include "ClassFactory.h"
+#include "CorProfiler.h"
+
+ClassFactory::ClassFactory() : refCount(0)
+{
+}
+
+ClassFactory::~ClassFactory()
+{
+}
+
+HRESULT STDMETHODCALLTYPE ClassFactory::QueryInterface(REFIID riid, void **ppvObject)
+{
+    if (riid == IID_IUnknown || riid == IID_IClassFactory)
+    {
+        *ppvObject = this;
+        this->AddRef();
+        return S_OK;
+    }
+
+    *ppvObject = nullptr;
+    return E_NOINTERFACE;
+}
+
+ULONG STDMETHODCALLTYPE ClassFactory::AddRef()
+{
+    return std::atomic_fetch_add(&this->refCount, 1) + 1;
+}
+
+ULONG STDMETHODCALLTYPE ClassFactory::Release()
+{
+    int count = std::atomic_fetch_sub(&this->refCount, 1) - 1;
+    if (count <= 0)
+    {
+        delete this;
+    }
+
+    return count;
+}
+
+HRESULT STDMETHODCALLTYPE ClassFactory::CreateInstance(IUnknown *pUnkOuter, REFIID riid, void **ppvObject)
+{
+    if (pUnkOuter != nullptr)
+    {
+        *ppvObject = nullptr;
+        return CLASS_E_NOAGGREGATION;
+    }
+
+    CorProfiler* profiler = new CorProfiler();
+    if (profiler == nullptr)
+    {
+        return E_FAIL;
+    }
+
+    return profiler->QueryInterface(riid, ppvObject);
+}
+
+HRESULT STDMETHODCALLTYPE ClassFactory::LockServer(BOOL fLock)
+{
+    return S_OK;
+}

--- a/ProfilingAPI/ReJITEnterLeaveHooks/ClassFactory.h
+++ b/ProfilingAPI/ReJITEnterLeaveHooks/ClassFactory.h
@@ -1,0 +1,22 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include "profiler_pal.h"
+#include "unknwn.h"
+#include <atomic>
+
+class ClassFactory : public IClassFactory
+{
+private:
+    std::atomic<int> refCount;
+public:
+    ClassFactory();
+    virtual ~ClassFactory();
+    HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void **ppvObject) override;
+    ULONG   STDMETHODCALLTYPE AddRef(void) override;
+    ULONG   STDMETHODCALLTYPE Release(void) override;
+    HRESULT STDMETHODCALLTYPE CreateInstance(IUnknown *pUnkOuter, REFIID riid, void **ppvObject) override;
+    HRESULT STDMETHODCALLTYPE LockServer(BOOL fLock) override;
+};

--- a/ProfilingAPI/ReJITEnterLeaveHooks/ClrProfiler.def
+++ b/ProfilingAPI/ReJITEnterLeaveHooks/ClrProfiler.def
@@ -1,0 +1,5 @@
+LIBRARY "ClrProfiler.Dll"
+
+EXPORTS
+    DllCanUnloadNow PRIVATE
+    DllGetClassObject PRIVATE

--- a/ProfilingAPI/ReJITEnterLeaveHooks/ClrProfiler.sln
+++ b/ProfilingAPI/ReJITEnterLeaveHooks/ClrProfiler.sln
@@ -1,0 +1,30 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.21005.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ClrProfiler", "ClrProfiler.vcxproj", "{91B6272F-5780-4C94-8071-DBBA7B4F67F3}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{57E0F3FA-5C6A-4298-9A45-AC331B8B8935}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+		Debug|x64 = Debug|x64
+		Release|Win32 = Release|Win32
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{91B6272F-5780-4C94-8071-DBBA7B4F67F3}.Debug|Win32.ActiveCfg = Debug|Win32
+		{91B6272F-5780-4C94-8071-DBBA7B4F67F3}.Debug|Win32.Build.0 = Debug|Win32
+		{91B6272F-5780-4C94-8071-DBBA7B4F67F3}.Debug|x64.ActiveCfg = Debug|x64
+		{91B6272F-5780-4C94-8071-DBBA7B4F67F3}.Debug|x64.Build.0 = Debug|x64
+		{91B6272F-5780-4C94-8071-DBBA7B4F67F3}.Release|Win32.ActiveCfg = Release|Win32
+		{91B6272F-5780-4C94-8071-DBBA7B4F67F3}.Release|Win32.Build.0 = Release|Win32
+		{91B6272F-5780-4C94-8071-DBBA7B4F67F3}.Release|x64.ActiveCfg = Release|x64
+		{91B6272F-5780-4C94-8071-DBBA7B4F67F3}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/ProfilingAPI/ReJITEnterLeaveHooks/ClrProfiler.vcxproj
+++ b/ProfilingAPI/ReJITEnterLeaveHooks/ClrProfiler.vcxproj
@@ -1,0 +1,153 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{91B6272F-5780-4C94-8071-DBBA7B4F67F3}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>ClrProfiler</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <IncludePath>$(VC_IncludePath);$(CORECLR_PATH)\src\pal\inc\rt;$(CORECLR_PATH)\src\pal\prebuilt\inc;$(CORECLR_PATH)\src\pal\inc;$(CORECLR_PATH)\src\inc;$(CORECLR_PATH)\bin\Product\$(BuildOS).$(BuildArch).$(BuildType)\inc;$(NETFXSDKDir)Include\um;$(WindowsSDK_IncludePath);</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <IncludePath>$(VC_IncludePath);$(CORECLR_PATH)\src\pal\inc\rt;$(CORECLR_PATH)\src\pal\prebuilt\inc;$(CORECLR_PATH)\src\pal\inc;$(CORECLR_PATH)\src\inc;$(CORECLR_PATH)\bin\Product\$(BuildOS).$(BuildArch).$(BuildType)\inc;$(NETFXSDKDir)Include\um;$(WindowsSDK_IncludePath);</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <IncludePath>$(VC_IncludePath);$(CORECLR_PATH)\src\pal\inc\rt;$(CORECLR_PATH)\src\pal\prebuilt\inc;$(CORECLR_PATH)\src\pal\inc;$(CORECLR_PATH)\src\inc;$(CORECLR_PATH)\bin\Product\$(BuildOS).$(BuildArch).$(BuildType)\inc;$(NETFXSDKDir)Include\um;$(WindowsSDK_IncludePath);</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <IncludePath>$(VC_IncludePath);$(CORECLR_PATH)\src\pal\inc\rt;$(CORECLR_PATH)\src\pal\prebuilt\inc;$(CORECLR_PATH)\src\pal\inc;$(CORECLR_PATH)\src\inc;$(CORECLR_PATH)\bin\Product\$(BuildOS).$(BuildArch).$(BuildType)\inc;$(NETFXSDKDir)Include\um;$(WindowsSDK_IncludePath);</IncludePath>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;FLIGHTRECORDER_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ModuleDefinitionFile>.\ClrProfiler.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;FLIGHTRECORDER_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <TreatWarningAsError>false</TreatWarningAsError>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ModuleDefinitionFile>.\ClrProfiler.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;FLIGHTRECORDER_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <TreatWarningAsError>true</TreatWarningAsError>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <ModuleDefinitionFile>.\ClrProfiler.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;FLIGHTRECORDER_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <TreatWarningAsError>true</TreatWarningAsError>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <ModuleDefinitionFile>.\ClrProfiler.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="ClassFactory.h" />
+    <ClInclude Include="CorProfiler.h" />
+    <ClInclude Include="ILRewriter.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="ClassFactory.cpp" />
+    <ClCompile Include="dllmain.cpp" />
+    <ClCompile Include="CorProfiler.cpp" />
+    <ClCompile Include="ILRewriter.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="ClrProfiler.def" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+</Project>

--- a/ProfilingAPI/ReJITEnterLeaveHooks/CorProfiler.cpp
+++ b/ProfilingAPI/ReJITEnterLeaveHooks/CorProfiler.cpp
@@ -1,0 +1,516 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include "CorProfiler.h"
+#include "corhlpr.h"
+#include "CComPtr.h"
+#include "ILRewriter.h"
+#include <string>
+
+static void STDMETHODCALLTYPE Enter(FunctionID functionId)
+{
+    printf("\r\nEnter %lx", functionId);
+}
+
+static void STDMETHODCALLTYPE Leave(FunctionID functionId)
+{
+    printf("\r\nLeave %lx", functionId);
+}
+
+COR_SIGNATURE enterLeaveMethodSignature             [] = { IMAGE_CEE_CS_CALLCONV_STDCALL, 0x01, ELEMENT_TYPE_VOID, ELEMENT_TYPE_I };
+
+void(STDMETHODCALLTYPE *EnterMethodAddress)(FunctionID) = &Enter;
+void(STDMETHODCALLTYPE *LeaveMethodAddress)(FunctionID) = &Leave;
+
+CorProfiler::CorProfiler() : refCount(0), corProfilerInfo(nullptr)
+{
+}
+
+CorProfiler::~CorProfiler()
+{
+    if (this->corProfilerInfo != nullptr)
+    {
+        this->corProfilerInfo->Release();
+        this->corProfilerInfo = nullptr;
+    }
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown *pICorProfilerInfoUnk)
+{
+    HRESULT queryInterfaceResult = pICorProfilerInfoUnk->QueryInterface(__uuidof(ICorProfilerInfo7), reinterpret_cast<void **>(&this->corProfilerInfo));
+
+    if (FAILED(queryInterfaceResult))
+    {
+        return E_FAIL;
+    }
+
+    DWORD eventMask = COR_PRF_MONITOR_JIT_COMPILATION                      |
+                      COR_PRF_DISABLE_TRANSPARENCY_CHECKS_UNDER_FULL_TRUST | /* helps the case where this profiler is used on Full CLR */
+                      COR_PRF_DISABLE_INLINING                             ;
+
+    auto hr = this->corProfilerInfo->SetEventMask(eventMask);
+
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::Shutdown()
+{
+    if (this->corProfilerInfo != nullptr)
+    {
+        this->corProfilerInfo->Release();
+        this->corProfilerInfo = nullptr;
+    }
+
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::AppDomainCreationStarted(AppDomainID appDomainId)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::AppDomainCreationFinished(AppDomainID appDomainId, HRESULT hrStatus)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::AppDomainShutdownStarted(AppDomainID appDomainId)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::AppDomainShutdownFinished(AppDomainID appDomainId, HRESULT hrStatus)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::AssemblyLoadStarted(AssemblyID assemblyId)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::AssemblyLoadFinished(AssemblyID assemblyId, HRESULT hrStatus)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::AssemblyUnloadStarted(AssemblyID assemblyId)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::AssemblyUnloadFinished(AssemblyID assemblyId, HRESULT hrStatus)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadStarted(ModuleID moduleId)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID moduleId, HRESULT hrStatus)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ModuleUnloadStarted(ModuleID moduleId)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ModuleUnloadFinished(ModuleID moduleId, HRESULT hrStatus)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ModuleAttachedToAssembly(ModuleID moduleId, AssemblyID AssemblyId)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ClassLoadStarted(ClassID classId)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ClassLoadFinished(ClassID classId, HRESULT hrStatus)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ClassUnloadStarted(ClassID classId)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ClassUnloadFinished(ClassID classId, HRESULT hrStatus)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::FunctionUnloadStarted(FunctionID functionId)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(FunctionID functionId, BOOL fIsSafeToBlock)
+{
+    HRESULT hr;
+    mdToken token;
+    ClassID classId;
+    ModuleID moduleId;
+
+    IfFailRet(this->corProfilerInfo->GetFunctionInfo(functionId, &classId, &moduleId, &token));
+
+    CComPtr<IMetaDataImport> metadataImport;
+    IfFailRet(this->corProfilerInfo->GetModuleMetaData(moduleId, ofRead | ofWrite, IID_IMetaDataImport, reinterpret_cast<IUnknown **>(&metadataImport)));
+
+    CComPtr<IMetaDataEmit> metadataEmit;
+    IfFailRet(metadataImport->QueryInterface(IID_IMetaDataEmit, reinterpret_cast<void **>(&metadataEmit)));
+
+    mdSignature enterLeaveMethodSignatureToken;
+    metadataEmit->GetTokenFromSig(enterLeaveMethodSignature, sizeof(enterLeaveMethodSignature), &enterLeaveMethodSignatureToken);
+
+    return RewriteIL(this->corProfilerInfo, nullptr, moduleId, token, functionId, reinterpret_cast<ULONGLONG>(EnterMethodAddress), reinterpret_cast<ULONGLONG>(LeaveMethodAddress), enterLeaveMethodSignatureToken);
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationFinished(FunctionID functionId, HRESULT hrStatus, BOOL fIsSafeToBlock)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::JITCachedFunctionSearchStarted(FunctionID functionId, BOOL *pbUseCachedFunction)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::JITCachedFunctionSearchFinished(FunctionID functionId, COR_PRF_JIT_CACHE result)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::JITFunctionPitched(FunctionID functionId)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::JITInlining(FunctionID callerId, FunctionID calleeId, BOOL *pfShouldInline)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ThreadCreated(ThreadID threadId)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ThreadDestroyed(ThreadID threadId)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ThreadAssignedToOSThread(ThreadID managedThreadId, DWORD osThreadId)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::RemotingClientInvocationStarted()
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::RemotingClientSendingMessage(GUID *pCookie, BOOL fIsAsync)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::RemotingClientReceivingReply(GUID *pCookie, BOOL fIsAsync)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::RemotingClientInvocationFinished()
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::RemotingServerReceivingMessage(GUID *pCookie, BOOL fIsAsync)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::RemotingServerInvocationStarted()
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::RemotingServerInvocationReturned()
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::RemotingServerSendingReply(GUID *pCookie, BOOL fIsAsync)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::UnmanagedToManagedTransition(FunctionID functionId, COR_PRF_TRANSITION_REASON reason)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ManagedToUnmanagedTransition(FunctionID functionId, COR_PRF_TRANSITION_REASON reason)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::RuntimeSuspendStarted(COR_PRF_SUSPEND_REASON suspendReason)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::RuntimeSuspendFinished()
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::RuntimeSuspendAborted()
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::RuntimeResumeStarted()
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::RuntimeResumeFinished()
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::RuntimeThreadSuspended(ThreadID threadId)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::RuntimeThreadResumed(ThreadID threadId)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::MovedReferences(ULONG cMovedObjectIDRanges, ObjectID oldObjectIDRangeStart[], ObjectID newObjectIDRangeStart[], ULONG cObjectIDRangeLength[])
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ObjectAllocated(ObjectID objectId, ClassID classId)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ObjectsAllocatedByClass(ULONG cClassCount, ClassID classIds[], ULONG cObjects[])
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ObjectReferences(ObjectID objectId, ClassID classId, ULONG cObjectRefs, ObjectID objectRefIds[])
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::RootReferences(ULONG cRootRefs, ObjectID rootRefIds[])
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionThrown(ObjectID thrownObjectId)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionSearchFunctionEnter(FunctionID functionId)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionSearchFunctionLeave()
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionSearchFilterEnter(FunctionID functionId)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionSearchFilterLeave()
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionSearchCatcherFound(FunctionID functionId)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionOSHandlerEnter(UINT_PTR __unused)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionOSHandlerLeave(UINT_PTR __unused)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionUnwindFunctionEnter(FunctionID functionId)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionUnwindFunctionLeave()
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionUnwindFinallyEnter(FunctionID functionId)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionUnwindFinallyLeave()
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionCatcherEnter(FunctionID functionId, ObjectID objectId)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionCatcherLeave()
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::COMClassicVTableCreated(ClassID wrappedClassId, REFGUID implementedIID, void *pVTable, ULONG cSlots)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::COMClassicVTableDestroyed(ClassID wrappedClassId, REFGUID implementedIID, void *pVTable)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionCLRCatcherFound()
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionCLRCatcherExecute()
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ThreadNameChanged(ThreadID threadId, ULONG cchName, WCHAR name[])
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::GarbageCollectionStarted(int cGenerations, BOOL generationCollected[], COR_PRF_GC_REASON reason)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::SurvivingReferences(ULONG cSurvivingObjectIDRanges, ObjectID objectIDRangeStart[], ULONG cObjectIDRangeLength[])
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::GarbageCollectionFinished()
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::FinalizeableObjectQueued(DWORD finalizerFlags, ObjectID objectID)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::RootReferences2(ULONG cRootRefs, ObjectID rootRefIds[], COR_PRF_GC_ROOT_KIND rootKinds[], COR_PRF_GC_ROOT_FLAGS rootFlags[], UINT_PTR rootIds[])
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::HandleCreated(GCHandleID handleId, ObjectID initialObjectId)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::HandleDestroyed(GCHandleID handleId)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::InitializeForAttach(IUnknown *pCorProfilerInfoUnk, void *pvClientData, UINT cbClientData)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ProfilerAttachComplete()
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ProfilerDetachSucceeded()
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ReJITCompilationStarted(FunctionID functionId, ReJITID rejitId, BOOL fIsSafeToBlock)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::GetReJITParameters(ModuleID moduleId, mdMethodDef methodId, ICorProfilerFunctionControl *pFunctionControl)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ReJITCompilationFinished(FunctionID functionId, ReJITID rejitId, HRESULT hrStatus, BOOL fIsSafeToBlock)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ReJITError(ModuleID moduleId, mdMethodDef methodId, FunctionID functionId, HRESULT hrStatus)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::MovedReferences2(ULONG cMovedObjectIDRanges, ObjectID oldObjectIDRangeStart[], ObjectID newObjectIDRangeStart[], SIZE_T cObjectIDRangeLength[])
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::SurvivingReferences2(ULONG cSurvivingObjectIDRanges, ObjectID objectIDRangeStart[], SIZE_T cObjectIDRangeLength[])
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ConditionalWeakTableElementReferences(ULONG cRootRefs, ObjectID keyRefIds[], ObjectID valueRefIds[], GCHandleID rootIds[])
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::GetAssemblyReferences(const WCHAR *wszAssemblyPath, ICorProfilerAssemblyReferenceProvider *pAsmRefProvider)
+{
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::ModuleInMemorySymbolsUpdated(ModuleID moduleId)
+{
+    return S_OK;
+}

--- a/ProfilingAPI/ReJITEnterLeaveHooks/CorProfiler.h
+++ b/ProfilingAPI/ReJITEnterLeaveHooks/CorProfiler.h
@@ -1,0 +1,146 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include <atomic>
+
+#include "profiler_pal.h"
+#include "cor.h"
+#include "corprof.h"
+
+class CorProfiler : public ICorProfilerCallback7
+{
+private:
+    std::atomic<int> refCount;
+    ICorProfilerInfo7* corProfilerInfo;
+public:
+    CorProfiler();
+    virtual ~CorProfiler();
+    HRESULT STDMETHODCALLTYPE Initialize(IUnknown* pICorProfilerInfoUnk) override;
+    HRESULT STDMETHODCALLTYPE Shutdown() override;
+    HRESULT STDMETHODCALLTYPE AppDomainCreationStarted(AppDomainID appDomainId) override;
+    HRESULT STDMETHODCALLTYPE AppDomainCreationFinished(AppDomainID appDomainId, HRESULT hrStatus) override;
+    HRESULT STDMETHODCALLTYPE AppDomainShutdownStarted(AppDomainID appDomainId) override;
+    HRESULT STDMETHODCALLTYPE AppDomainShutdownFinished(AppDomainID appDomainId, HRESULT hrStatus) override;
+    HRESULT STDMETHODCALLTYPE AssemblyLoadStarted(AssemblyID assemblyId) override;
+    HRESULT STDMETHODCALLTYPE AssemblyLoadFinished(AssemblyID assemblyId, HRESULT hrStatus) override;
+    HRESULT STDMETHODCALLTYPE AssemblyUnloadStarted(AssemblyID assemblyId) override;
+    HRESULT STDMETHODCALLTYPE AssemblyUnloadFinished(AssemblyID assemblyId, HRESULT hrStatus) override;
+    HRESULT STDMETHODCALLTYPE ModuleLoadStarted(ModuleID moduleId) override;
+    HRESULT STDMETHODCALLTYPE ModuleLoadFinished(ModuleID moduleId, HRESULT hrStatus) override;
+    HRESULT STDMETHODCALLTYPE ModuleUnloadStarted(ModuleID moduleId) override;
+    HRESULT STDMETHODCALLTYPE ModuleUnloadFinished(ModuleID moduleId, HRESULT hrStatus) override;
+    HRESULT STDMETHODCALLTYPE ModuleAttachedToAssembly(ModuleID moduleId, AssemblyID AssemblyId) override;
+    HRESULT STDMETHODCALLTYPE ClassLoadStarted(ClassID classId) override;
+    HRESULT STDMETHODCALLTYPE ClassLoadFinished(ClassID classId, HRESULT hrStatus) override;
+    HRESULT STDMETHODCALLTYPE ClassUnloadStarted(ClassID classId) override;
+    HRESULT STDMETHODCALLTYPE ClassUnloadFinished(ClassID classId, HRESULT hrStatus) override;
+    HRESULT STDMETHODCALLTYPE FunctionUnloadStarted(FunctionID functionId) override;
+    HRESULT STDMETHODCALLTYPE JITCompilationStarted(FunctionID functionId, BOOL fIsSafeToBlock) override;
+    HRESULT STDMETHODCALLTYPE JITCompilationFinished(FunctionID functionId, HRESULT hrStatus, BOOL fIsSafeToBlock) override;
+    HRESULT STDMETHODCALLTYPE JITCachedFunctionSearchStarted(FunctionID functionId, BOOL* pbUseCachedFunction) override;
+    HRESULT STDMETHODCALLTYPE JITCachedFunctionSearchFinished(FunctionID functionId, COR_PRF_JIT_CACHE result) override;
+    HRESULT STDMETHODCALLTYPE JITFunctionPitched(FunctionID functionId) override;
+    HRESULT STDMETHODCALLTYPE JITInlining(FunctionID callerId, FunctionID calleeId, BOOL* pfShouldInline) override;
+    HRESULT STDMETHODCALLTYPE ThreadCreated(ThreadID threadId) override;
+    HRESULT STDMETHODCALLTYPE ThreadDestroyed(ThreadID threadId) override;
+    HRESULT STDMETHODCALLTYPE ThreadAssignedToOSThread(ThreadID managedThreadId, DWORD osThreadId) override;
+    HRESULT STDMETHODCALLTYPE RemotingClientInvocationStarted() override;
+    HRESULT STDMETHODCALLTYPE RemotingClientSendingMessage(GUID* pCookie, BOOL fIsAsync) override;
+    HRESULT STDMETHODCALLTYPE RemotingClientReceivingReply(GUID* pCookie, BOOL fIsAsync) override;
+    HRESULT STDMETHODCALLTYPE RemotingClientInvocationFinished() override;
+    HRESULT STDMETHODCALLTYPE RemotingServerReceivingMessage(GUID* pCookie, BOOL fIsAsync) override;
+    HRESULT STDMETHODCALLTYPE RemotingServerInvocationStarted() override;
+    HRESULT STDMETHODCALLTYPE RemotingServerInvocationReturned() override;
+    HRESULT STDMETHODCALLTYPE RemotingServerSendingReply(GUID* pCookie, BOOL fIsAsync) override;
+    HRESULT STDMETHODCALLTYPE UnmanagedToManagedTransition(FunctionID functionId, COR_PRF_TRANSITION_REASON reason) override;
+    HRESULT STDMETHODCALLTYPE ManagedToUnmanagedTransition(FunctionID functionId, COR_PRF_TRANSITION_REASON reason) override;
+    HRESULT STDMETHODCALLTYPE RuntimeSuspendStarted(COR_PRF_SUSPEND_REASON suspendReason) override;
+    HRESULT STDMETHODCALLTYPE RuntimeSuspendFinished() override;
+    HRESULT STDMETHODCALLTYPE RuntimeSuspendAborted() override;
+    HRESULT STDMETHODCALLTYPE RuntimeResumeStarted() override;
+    HRESULT STDMETHODCALLTYPE RuntimeResumeFinished() override;
+    HRESULT STDMETHODCALLTYPE RuntimeThreadSuspended(ThreadID threadId) override;
+    HRESULT STDMETHODCALLTYPE RuntimeThreadResumed(ThreadID threadId) override;
+    HRESULT STDMETHODCALLTYPE MovedReferences(ULONG cMovedObjectIDRanges, ObjectID oldObjectIDRangeStart[], ObjectID newObjectIDRangeStart[], ULONG cObjectIDRangeLength[]) override;
+    HRESULT STDMETHODCALLTYPE ObjectAllocated(ObjectID objectId, ClassID classId) override;
+    HRESULT STDMETHODCALLTYPE ObjectsAllocatedByClass(ULONG cClassCount, ClassID classIds[], ULONG cObjects[]) override;
+    HRESULT STDMETHODCALLTYPE ObjectReferences(ObjectID objectId, ClassID classId, ULONG cObjectRefs, ObjectID objectRefIds[]) override;
+    HRESULT STDMETHODCALLTYPE RootReferences(ULONG cRootRefs, ObjectID rootRefIds[]) override;
+    HRESULT STDMETHODCALLTYPE ExceptionThrown(ObjectID thrownObjectId) override;
+    HRESULT STDMETHODCALLTYPE ExceptionSearchFunctionEnter(FunctionID functionId) override;
+    HRESULT STDMETHODCALLTYPE ExceptionSearchFunctionLeave() override;
+    HRESULT STDMETHODCALLTYPE ExceptionSearchFilterEnter(FunctionID functionId) override;
+    HRESULT STDMETHODCALLTYPE ExceptionSearchFilterLeave() override;
+    HRESULT STDMETHODCALLTYPE ExceptionSearchCatcherFound(FunctionID functionId) override;
+    HRESULT STDMETHODCALLTYPE ExceptionOSHandlerEnter(UINT_PTR __unused) override;
+    HRESULT STDMETHODCALLTYPE ExceptionOSHandlerLeave(UINT_PTR __unused) override;
+    HRESULT STDMETHODCALLTYPE ExceptionUnwindFunctionEnter(FunctionID functionId) override;
+    HRESULT STDMETHODCALLTYPE ExceptionUnwindFunctionLeave() override;
+    HRESULT STDMETHODCALLTYPE ExceptionUnwindFinallyEnter(FunctionID functionId) override;
+    HRESULT STDMETHODCALLTYPE ExceptionUnwindFinallyLeave() override;
+    HRESULT STDMETHODCALLTYPE ExceptionCatcherEnter(FunctionID functionId, ObjectID objectId) override;
+    HRESULT STDMETHODCALLTYPE ExceptionCatcherLeave() override;
+    HRESULT STDMETHODCALLTYPE COMClassicVTableCreated(ClassID wrappedClassId, REFGUID implementedIID, void* pVTable, ULONG cSlots) override;
+    HRESULT STDMETHODCALLTYPE COMClassicVTableDestroyed(ClassID wrappedClassId, REFGUID implementedIID, void* pVTable) override;
+    HRESULT STDMETHODCALLTYPE ExceptionCLRCatcherFound() override;
+    HRESULT STDMETHODCALLTYPE ExceptionCLRCatcherExecute() override;
+    HRESULT STDMETHODCALLTYPE ThreadNameChanged(ThreadID threadId, ULONG cchName, WCHAR name[]) override;
+    HRESULT STDMETHODCALLTYPE GarbageCollectionStarted(int cGenerations, BOOL generationCollected[], COR_PRF_GC_REASON reason) override;
+    HRESULT STDMETHODCALLTYPE SurvivingReferences(ULONG cSurvivingObjectIDRanges, ObjectID objectIDRangeStart[], ULONG cObjectIDRangeLength[]) override;
+    HRESULT STDMETHODCALLTYPE GarbageCollectionFinished() override;
+    HRESULT STDMETHODCALLTYPE FinalizeableObjectQueued(DWORD finalizerFlags, ObjectID objectID) override;
+    HRESULT STDMETHODCALLTYPE RootReferences2(ULONG cRootRefs, ObjectID rootRefIds[], COR_PRF_GC_ROOT_KIND rootKinds[], COR_PRF_GC_ROOT_FLAGS rootFlags[], UINT_PTR rootIds[]) override;
+    HRESULT STDMETHODCALLTYPE HandleCreated(GCHandleID handleId, ObjectID initialObjectId) override;
+    HRESULT STDMETHODCALLTYPE HandleDestroyed(GCHandleID handleId) override;
+    HRESULT STDMETHODCALLTYPE InitializeForAttach(IUnknown* pCorProfilerInfoUnk, void* pvClientData, UINT cbClientData) override;
+    HRESULT STDMETHODCALLTYPE ProfilerAttachComplete() override;
+    HRESULT STDMETHODCALLTYPE ProfilerDetachSucceeded() override;
+    HRESULT STDMETHODCALLTYPE ReJITCompilationStarted(FunctionID functionId, ReJITID rejitId, BOOL fIsSafeToBlock) override;
+    HRESULT STDMETHODCALLTYPE GetReJITParameters(ModuleID moduleId, mdMethodDef methodId, ICorProfilerFunctionControl* pFunctionControl) override;
+    HRESULT STDMETHODCALLTYPE ReJITCompilationFinished(FunctionID functionId, ReJITID rejitId, HRESULT hrStatus, BOOL fIsSafeToBlock) override;
+    HRESULT STDMETHODCALLTYPE ReJITError(ModuleID moduleId, mdMethodDef methodId, FunctionID functionId, HRESULT hrStatus) override;
+    HRESULT STDMETHODCALLTYPE MovedReferences2(ULONG cMovedObjectIDRanges, ObjectID oldObjectIDRangeStart[], ObjectID newObjectIDRangeStart[], SIZE_T cObjectIDRangeLength[]) override;
+    HRESULT STDMETHODCALLTYPE SurvivingReferences2(ULONG cSurvivingObjectIDRanges, ObjectID objectIDRangeStart[], SIZE_T cObjectIDRangeLength[]) override;
+    HRESULT STDMETHODCALLTYPE ConditionalWeakTableElementReferences(ULONG cRootRefs, ObjectID keyRefIds[], ObjectID valueRefIds[], GCHandleID rootIds[]) override;
+    HRESULT STDMETHODCALLTYPE GetAssemblyReferences(const WCHAR* wszAssemblyPath, ICorProfilerAssemblyReferenceProvider* pAsmRefProvider) override;
+    HRESULT STDMETHODCALLTYPE ModuleInMemorySymbolsUpdated(ModuleID moduleId) override;
+
+    HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void **ppvObject) override
+    {
+        if (riid == __uuidof(ICorProfilerCallback7) ||
+            riid == __uuidof(ICorProfilerCallback6) ||
+            riid == __uuidof(ICorProfilerCallback5) ||
+            riid == __uuidof(ICorProfilerCallback4) ||
+            riid == __uuidof(ICorProfilerCallback3) ||
+            riid == __uuidof(ICorProfilerCallback2) ||
+            riid == __uuidof(ICorProfilerCallback)  ||
+            riid == IID_IUnknown)
+        {
+            *ppvObject = this;
+            this->AddRef();
+            return S_OK;
+        }
+
+        *ppvObject = nullptr;
+        return E_NOINTERFACE;
+    }
+
+    ULONG STDMETHODCALLTYPE AddRef(void) override
+    {
+        return std::atomic_fetch_add(&this->refCount, 1) + 1;
+    }
+
+    ULONG STDMETHODCALLTYPE Release(void) override
+    {
+        int count = std::atomic_fetch_sub(&this->refCount, 1) - 1;
+
+        if (count <= 0)
+        {
+            delete this;
+        }
+
+        return count;
+    }
+};

--- a/ProfilingAPI/ReJITEnterLeaveHooks/ILRewriter.cpp
+++ b/ProfilingAPI/ReJITEnterLeaveHooks/ILRewriter.cpp
@@ -1,0 +1,841 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include "cor.h"
+#include "corprof.h"
+#include "ILRewriter.h"
+#include <corhlpr.cpp>
+#include <cassert>
+#include <stdexcept>
+
+#undef IfFailRet
+#define IfFailRet(EXPR) do { HRESULT hr = (EXPR); if(FAILED(hr)) { return (hr); } } while (0)
+
+#undef IfNullRet
+#define IfNullRet(EXPR) do { if ((EXPR) == NULL) return E_OUTOFMEMORY; } while (0)
+
+struct ILInstr
+{
+    ILInstr *       m_pNext;
+    ILInstr *       m_pPrev;
+
+    unsigned        m_opcode;
+    unsigned        m_offset;
+
+    union
+    {
+        ILInstr *   m_pTarget;
+        INT8        m_Arg8;
+        INT16       m_Arg16;
+        INT32       m_Arg32;
+        INT64       m_Arg64;
+    };
+};
+
+struct EHClause
+{
+    CorExceptionFlag            m_Flags;
+    ILInstr *                   m_pTryBegin;
+    ILInstr *                   m_pTryEnd;
+    ILInstr *                   m_pHandlerBegin;    // First instruction inside the handler
+    ILInstr *                   m_pHandlerEnd;      // Last instruction inside the handler
+    union
+    {
+        DWORD                   m_ClassToken;   // use for type-based exception handlers
+        ILInstr *               m_pFilter;      // use for filter-based exception handlers (COR_ILEXCEPTION_CLAUSE_FILTER is set)
+    };
+};
+
+typedef enum
+{
+#define OPDEF(c,s,pop,push,args,type,l,s1,s2,ctrl) c,
+#include "opcode.def"
+#undef OPDEF
+    CEE_COUNT,
+    CEE_SWITCH_ARG, // special internal instructions
+} OPCODE;
+
+#define OPCODEFLAGS_SizeMask        0x0F
+#define OPCODEFLAGS_BranchTarget    0x10
+#define OPCODEFLAGS_Switch          0x20
+
+static const BYTE s_OpCodeFlags[] =
+{
+#define InlineNone           0
+#define ShortInlineVar       1
+#define InlineVar            2
+#define ShortInlineI         1
+#define InlineI              4
+#define InlineI8             8
+#define ShortInlineR         4
+#define InlineR              8
+#define ShortInlineBrTarget  1 | OPCODEFLAGS_BranchTarget
+#define InlineBrTarget       4 | OPCODEFLAGS_BranchTarget
+#define InlineMethod         4
+#define InlineField          4
+#define InlineType           4
+#define InlineString         4
+#define InlineSig            4
+#define InlineRVA            4
+#define InlineTok            4
+#define InlineSwitch         0 | OPCODEFLAGS_Switch
+
+#define OPDEF(c,s,pop,push,args,type,l,s1,s2,flow) args,
+#include "opcode.def"
+#undef OPDEF
+
+#undef InlineNone
+#undef ShortInlineVar
+#undef InlineVar
+#undef ShortInlineI
+#undef InlineI
+#undef InlineI8
+#undef ShortInlineR
+#undef InlineR
+#undef ShortInlineBrTarget
+#undef InlineBrTarget
+#undef InlineMethod
+#undef InlineField
+#undef InlineType
+#undef InlineString
+#undef InlineSig
+#undef InlineRVA
+#undef InlineTok
+#undef InlineSwitch
+    0,                              // CEE_COUNT
+    4 | OPCODEFLAGS_BranchTarget,   // CEE_SWITCH_ARG
+};
+
+static int k_rgnStackPushes[] = {
+
+#define OPDEF(c,s,pop,push,args,type,l,s1,s2,ctrl) \
+	 push ,
+
+#define Push0    0
+#define Push1    1
+#define PushI    1
+#define PushI4   1
+#define PushR4   1
+#define PushI8   1
+#define PushR8   1
+#define PushRef  1
+#define VarPush  1          // Test code doesn't call vararg fcns, so this should not be used
+
+#include "opcode.def"
+
+#undef Push0   
+#undef Push1   
+#undef PushI   
+#undef PushI4  
+#undef PushR4  
+#undef PushI8  
+#undef PushR8  
+#undef PushRef 
+#undef VarPush 
+#undef OPDEF
+};
+
+class ILRewriter
+{
+private:
+    ICorProfilerInfo * m_pICorProfilerInfo;
+    ICorProfilerFunctionControl * m_pICorProfilerFunctionControl;
+
+    ModuleID    m_moduleId;
+    mdToken     m_tkMethod;
+
+    mdToken     m_tkLocalVarSig;
+    unsigned    m_maxStack;
+    unsigned    m_flags;
+    bool        m_fGenerateTinyHeader;
+
+    ILInstr m_IL; // Double linked list of all il instructions
+
+    unsigned    m_nEH;
+    EHClause *  m_pEH;
+
+    // Helper table for importing.  Sparse array that maps BYTE offset of beginning of an
+    // instruction to that instruction's ILInstr*.  BYTE offsets that don't correspond
+    // to the beginning of an instruction are mapped to NULL.
+    ILInstr **  m_pOffsetToInstr;
+    unsigned    m_CodeSize;
+
+    unsigned    m_nInstrs;
+
+    BYTE *      m_pOutputBuffer;
+
+    IMethodMalloc * m_pIMethodMalloc;
+
+public:
+    ILRewriter(ICorProfilerInfo * pICorProfilerInfo, ICorProfilerFunctionControl * pICorProfilerFunctionControl, ModuleID moduleID, mdToken tkMethod)
+        : m_pICorProfilerInfo(pICorProfilerInfo), m_pICorProfilerFunctionControl(pICorProfilerFunctionControl),
+        m_moduleId(moduleID), m_tkMethod(tkMethod), m_fGenerateTinyHeader(false),
+        m_pEH(nullptr), m_pOffsetToInstr(nullptr), m_pOutputBuffer(nullptr), m_pIMethodMalloc(nullptr)
+    {
+        m_IL.m_pNext = &m_IL;
+        m_IL.m_pPrev = &m_IL;
+
+        m_nInstrs = 0;
+    }
+
+    ~ILRewriter()
+    {
+        ILInstr * p = m_IL.m_pNext;
+        while (p != &m_IL)
+        {
+            ILInstr * t = p->m_pNext;
+            delete p;
+            p = t;
+        }
+        delete[] m_pEH;
+        delete[] m_pOffsetToInstr;
+        delete[] m_pOutputBuffer;
+
+        if (m_pIMethodMalloc)
+            m_pIMethodMalloc->Release();
+    }
+
+    /////////////////////////////////////////////////////////////////////////////////////////////////
+    //
+    // I M P O R T
+    //
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+
+    HRESULT Import()
+    {
+        LPCBYTE pMethodBytes;
+
+        IfFailRet(m_pICorProfilerInfo->GetILFunctionBody(
+            m_moduleId, m_tkMethod, &pMethodBytes, NULL));
+
+        COR_ILMETHOD_DECODER decoder((COR_ILMETHOD*)pMethodBytes);
+
+        // Import the header flags
+        m_tkLocalVarSig = decoder.GetLocalVarSigTok();
+        m_maxStack = decoder.GetMaxStack();
+        m_flags = (decoder.GetFlags() & CorILMethod_InitLocals);
+
+        m_CodeSize = decoder.GetCodeSize();
+
+        IfFailRet(ImportIL(decoder.Code));
+
+        IfFailRet(ImportEH(decoder.EH, decoder.EHCount()));
+
+        return S_OK;
+    }
+
+    HRESULT ImportIL(LPCBYTE pIL)
+    {
+        m_pOffsetToInstr = new ILInstr*[m_CodeSize + 1];
+        IfNullRet(m_pOffsetToInstr);
+
+        ZeroMemory(m_pOffsetToInstr, m_CodeSize * sizeof(ILInstr*));
+
+        // Set the sentinel instruction
+        m_pOffsetToInstr[m_CodeSize] = &m_IL;
+        m_IL.m_opcode = -1;
+
+        bool fBranch = false;
+        unsigned offset = 0;
+        while (offset < m_CodeSize)
+        {
+            unsigned startOffset = offset;
+            unsigned opcode = pIL[offset++];
+
+            if (opcode == CEE_PREFIX1)
+            {
+                if (offset >= m_CodeSize)
+                {
+                    assert(false);
+                    return COR_E_INVALIDPROGRAM;
+                }
+                opcode = 0x100 + pIL[offset++];
+            }
+
+            if ((CEE_PREFIX7 <= opcode) && (opcode <= CEE_PREFIX2))
+            {
+                // NOTE: CEE_PREFIX2-7 are currently not supported
+                assert(false);
+                return COR_E_INVALIDPROGRAM;
+            }
+
+            if (opcode >= CEE_COUNT)
+            {
+                assert(false);
+                return COR_E_INVALIDPROGRAM;
+            }
+
+            BYTE flags = s_OpCodeFlags[opcode];
+
+            int size = (flags & OPCODEFLAGS_SizeMask);
+            if (offset + size > m_CodeSize)
+            {
+                assert(false);
+                return COR_E_INVALIDPROGRAM;
+            }
+
+            ILInstr * pInstr = NewILInstr();
+            IfNullRet(pInstr);
+
+            pInstr->m_opcode = opcode;
+
+            InsertBefore(&m_IL, pInstr);
+
+            m_pOffsetToInstr[startOffset] = pInstr;
+
+            switch (flags)
+            {
+            case 0:
+                break;
+            case 1:
+                pInstr->m_Arg8 = *(UNALIGNED INT8 *)&(pIL[offset]);
+                break;
+            case 2:
+                pInstr->m_Arg16 = *(UNALIGNED INT16 *)&(pIL[offset]);
+                break;
+            case 4:
+                pInstr->m_Arg32 = *(UNALIGNED INT32 *)&(pIL[offset]);
+                break;
+            case 8:
+                pInstr->m_Arg64 = *(UNALIGNED INT64 *)&(pIL[offset]);
+                break;
+            case 1 | OPCODEFLAGS_BranchTarget:
+                pInstr->m_Arg32 = offset + 1 + *(UNALIGNED INT8 *)&(pIL[offset]);
+                fBranch = true;
+                break;
+            case 4 | OPCODEFLAGS_BranchTarget:
+                pInstr->m_Arg32 = offset + 4 + *(UNALIGNED INT32 *)&(pIL[offset]);
+                fBranch = true;
+                break;
+            case 0 | OPCODEFLAGS_Switch:
+            {
+                if (offset + sizeof(INT32) > m_CodeSize)
+                {
+                    assert(false);
+                    return COR_E_INVALIDPROGRAM;
+                }
+
+                unsigned nTargets = *(UNALIGNED INT32 *)&(pIL[offset]);
+                pInstr->m_Arg32 = nTargets;
+                offset += sizeof(INT32);
+
+                unsigned base = offset + nTargets * sizeof(INT32);
+
+                for (unsigned iTarget = 0; iTarget < nTargets; iTarget++)
+                {
+                    if (offset + sizeof(INT32) > m_CodeSize)
+                    {
+                        assert(false);
+                        return COR_E_INVALIDPROGRAM;
+                    }
+
+                    pInstr = NewILInstr();
+                    IfNullRet(pInstr);
+
+                    pInstr->m_opcode = CEE_SWITCH_ARG;
+
+                    pInstr->m_Arg32 = base + *(UNALIGNED INT32 *)&(pIL[offset]);
+                    offset += sizeof(INT32);
+
+                    InsertBefore(&m_IL, pInstr);
+                }
+                fBranch = true;
+                break;
+            }
+            default:
+                assert(false);
+                break;
+            }
+            offset += size;
+        }
+        assert(offset == m_CodeSize);
+
+        if (fBranch)
+        {
+            // Go over all control flow instructions and resolve the targets
+            for (ILInstr * pInstr = m_IL.m_pNext; pInstr != &m_IL; pInstr = pInstr->m_pNext)
+            {
+                if (s_OpCodeFlags[pInstr->m_opcode] & OPCODEFLAGS_BranchTarget)
+                    pInstr->m_pTarget = GetInstrFromOffset(pInstr->m_Arg32);
+            }
+        }
+
+        return S_OK;
+    }
+
+    HRESULT ImportEH(const COR_ILMETHOD_SECT_EH* pILEH, unsigned nEH)
+    {
+        assert(m_pEH == NULL);
+
+        m_nEH = nEH;
+
+        if (nEH == 0)
+            return S_OK;
+
+        IfNullRet(m_pEH = new EHClause[m_nEH]);
+        for (unsigned iEH = 0; iEH < m_nEH; iEH++)
+        {
+            // If the EH clause is in tiny form, the call to pILEH->EHClause() below will
+            // use this as a scratch buffer to expand the EH clause into its fat form.
+            COR_ILMETHOD_SECT_EH_CLAUSE_FAT scratch;
+
+            const COR_ILMETHOD_SECT_EH_CLAUSE_FAT* ehInfo;
+            ehInfo = (COR_ILMETHOD_SECT_EH_CLAUSE_FAT*)pILEH->EHClause(iEH, &scratch);
+
+            EHClause* clause = &(m_pEH[iEH]);
+            clause->m_Flags = ehInfo->GetFlags();
+
+            clause->m_pTryBegin = GetInstrFromOffset(ehInfo->GetTryOffset());
+            clause->m_pTryEnd = GetInstrFromOffset(ehInfo->GetTryOffset() + ehInfo->GetTryLength());
+            clause->m_pHandlerBegin = GetInstrFromOffset(ehInfo->GetHandlerOffset());
+            clause->m_pHandlerEnd = GetInstrFromOffset(ehInfo->GetHandlerOffset() + ehInfo->GetHandlerLength())->m_pPrev;
+            if ((clause->m_Flags & COR_ILEXCEPTION_CLAUSE_FILTER) == 0)
+                clause->m_ClassToken = ehInfo->GetClassToken();
+            else
+                clause->m_pFilter = GetInstrFromOffset(ehInfo->GetFilterOffset());
+        }
+
+        return S_OK;
+    }
+
+    ILInstr* NewILInstr()
+    {
+        m_nInstrs++;
+        return new ILInstr();
+    }
+
+    ILInstr* GetInstrFromOffset(unsigned offset)
+    {
+        ILInstr * pInstr = NULL;
+
+        if (offset <= m_CodeSize)
+            pInstr = m_pOffsetToInstr[offset];
+
+        assert(pInstr != NULL);
+        return pInstr;
+    }
+
+    void InsertBefore(ILInstr * pWhere, ILInstr * pWhat)
+    {
+        pWhat->m_pNext = pWhere;
+        pWhat->m_pPrev = pWhere->m_pPrev;
+
+        pWhat->m_pNext->m_pPrev = pWhat;
+        pWhat->m_pPrev->m_pNext = pWhat;
+
+        AdjustState(pWhat);
+    }
+
+    void InsertAfter(ILInstr * pWhere, ILInstr * pWhat)
+    {
+        pWhat->m_pNext = pWhere->m_pNext;
+        pWhat->m_pPrev = pWhere;
+
+        pWhat->m_pNext->m_pPrev = pWhat;
+        pWhat->m_pPrev->m_pNext = pWhat;
+
+        AdjustState(pWhat);
+    }
+
+    void AdjustState(ILInstr * pNewInstr)
+    {
+        m_maxStack += k_rgnStackPushes[pNewInstr->m_opcode];
+    }
+
+
+    ILInstr * GetILList()
+    {
+        return &m_IL;
+    }
+
+    /////////////////////////////////////////////////////////////////////////////////////////////////
+    //
+    // E X P O R T
+    //
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+    HRESULT Export()
+    {
+        // One instruction produces 6 bytes in the worst case
+        unsigned maxSize = m_nInstrs * 6;
+
+        m_pOutputBuffer = new BYTE[maxSize];
+        IfNullRet(m_pOutputBuffer);
+
+    again:
+        BYTE * pIL = m_pOutputBuffer;
+
+        bool fBranch = false;
+        unsigned offset = 0;
+
+        // Go over all instructions and produce code for them
+        for (ILInstr * pInstr = m_IL.m_pNext; pInstr != &m_IL; pInstr = pInstr->m_pNext)
+        {
+            pInstr->m_offset = offset;
+
+            unsigned opcode = pInstr->m_opcode;
+            if (opcode < CEE_COUNT)
+            {
+                // CEE_PREFIX1 refers not to instruction prefixes (like tail.), but to
+                // the lead byte of multi-byte opcodes. For now, the only lead byte
+                // supported is CEE_PREFIX1 = 0xFE.
+                if (opcode >= 0x100)
+                    m_pOutputBuffer[offset++] = CEE_PREFIX1;
+
+                // This appears to depend on an implicit conversion from
+                // unsigned opcode down to BYTE, to deliberately lose data and have
+                // opcode >= 0x100 wrap around to 0.
+                m_pOutputBuffer[offset++] = (opcode & 0xFF);
+            }
+
+            assert(pInstr->m_opcode < _countof(s_OpCodeFlags));
+            BYTE flags = s_OpCodeFlags[pInstr->m_opcode];
+            switch (flags)
+            {
+            case 0:
+                break;
+            case 1:
+                *(UNALIGNED INT8 *)&(pIL[offset]) = pInstr->m_Arg8;
+                break;
+            case 2:
+                *(UNALIGNED INT16 *)&(pIL[offset]) = pInstr->m_Arg16;
+                break;
+            case 4:
+                *(UNALIGNED INT32 *)&(pIL[offset]) = pInstr->m_Arg32;
+                break;
+            case 8:
+                *(UNALIGNED INT64 *)&(pIL[offset]) = pInstr->m_Arg64;
+                break;
+            case 1 | OPCODEFLAGS_BranchTarget:
+                fBranch = true;
+                break;
+            case 4 | OPCODEFLAGS_BranchTarget:
+                fBranch = true;
+                break;
+            case 0 | OPCODEFLAGS_Switch:
+                *(UNALIGNED INT32 *)&(pIL[offset]) = pInstr->m_Arg32;
+                offset += sizeof(INT32);
+                break;
+            default:
+                assert(false);
+                break;
+            }
+            offset += (flags & OPCODEFLAGS_SizeMask);
+        }
+        m_IL.m_offset = offset;
+
+        if (fBranch)
+        {
+            bool fTryAgain = false;
+            unsigned switchBase = 0;
+
+            // Go over all control flow instructions and resolve the targets
+            for (ILInstr * pInstr = m_IL.m_pNext; pInstr != &m_IL; pInstr = pInstr->m_pNext)
+            {
+                unsigned opcode = pInstr->m_opcode;
+
+                if (pInstr->m_opcode == CEE_SWITCH)
+                {
+                    switchBase = pInstr->m_offset + 1 + sizeof(INT32) * (pInstr->m_Arg32 + 1);
+                    continue;
+                }
+                if (opcode == CEE_SWITCH_ARG)
+                {
+                    // Switch args are special
+                    *(UNALIGNED INT32 *)&(pIL[pInstr->m_offset]) = pInstr->m_pTarget->m_offset - switchBase;
+                    continue;
+                }
+
+                BYTE flags = s_OpCodeFlags[pInstr->m_opcode];
+
+                if (flags & OPCODEFLAGS_BranchTarget)
+                {
+                    int delta = pInstr->m_pTarget->m_offset - pInstr->m_pNext->m_offset;
+
+                    switch (flags)
+                    {
+                    case 1 | OPCODEFLAGS_BranchTarget:
+                        // Check if delta is too big to fit into an INT8.
+                        // 
+                        // (see #pragma at top of file)
+                        if ((INT8)delta != delta)
+                        {
+                            if (opcode == CEE_LEAVE_S)
+                            {
+                                pInstr->m_opcode = CEE_LEAVE;
+                            }
+                            else
+                            {
+                                assert(opcode >= CEE_BR_S && opcode <= CEE_BLT_UN_S);
+                                pInstr->m_opcode = opcode - CEE_BR_S + CEE_BR;
+                                assert(pInstr->m_opcode >= CEE_BR && pInstr->m_opcode <= CEE_BLT_UN);
+                            }
+                            fTryAgain = true;
+                            continue;
+                        }
+                        *(UNALIGNED INT8 *)&(pIL[pInstr->m_pNext->m_offset - sizeof(INT8)]) = delta;
+                        break;
+                    case 4 | OPCODEFLAGS_BranchTarget:
+                        *(UNALIGNED INT32 *)&(pIL[pInstr->m_pNext->m_offset - sizeof(INT32)]) = delta;
+                        break;
+                    default:
+                        assert(false);
+                        break;
+                    }
+                }
+            }
+
+            // Do the whole thing again if we changed the size of some branch targets
+            if (fTryAgain)
+                goto again;
+        }
+
+        unsigned codeSize = offset;
+        unsigned totalSize;
+        LPBYTE pBody = NULL;
+        if (m_fGenerateTinyHeader)
+        {
+            // Make sure we can fit in a tiny header
+            if (codeSize >= 64)
+                return E_FAIL;
+
+            totalSize = sizeof(IMAGE_COR_ILMETHOD_TINY) + codeSize;
+            pBody = AllocateILMemory(totalSize);
+            IfNullRet(pBody);
+
+            BYTE * pCurrent = pBody;
+
+            // Here's the tiny header
+            *pCurrent = (BYTE)(CorILMethod_TinyFormat | (codeSize << 2));
+            pCurrent += sizeof(IMAGE_COR_ILMETHOD_TINY);
+
+            // And the body
+            CopyMemory(pCurrent, m_pOutputBuffer, codeSize);
+        }
+        else
+        {
+            // Use FAT header
+
+            unsigned alignedCodeSize = (offset + 3) & ~3;
+
+            totalSize = sizeof(IMAGE_COR_ILMETHOD_FAT) + alignedCodeSize +
+                (m_nEH ? (sizeof(IMAGE_COR_ILMETHOD_SECT_FAT) + sizeof(IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_FAT) * m_nEH) : 0);
+
+            pBody = AllocateILMemory(totalSize);
+            IfNullRet(pBody);
+
+            BYTE * pCurrent = pBody;
+
+            IMAGE_COR_ILMETHOD_FAT *pHeader = (IMAGE_COR_ILMETHOD_FAT *)pCurrent;
+            pHeader->Flags = m_flags | (m_nEH ? CorILMethod_MoreSects : 0) | CorILMethod_FatFormat;
+            pHeader->Size = sizeof(IMAGE_COR_ILMETHOD_FAT) / sizeof(DWORD);
+            pHeader->MaxStack = m_maxStack;
+            pHeader->CodeSize = offset;
+            pHeader->LocalVarSigTok = m_tkLocalVarSig;
+
+            pCurrent = (BYTE*)(pHeader + 1);
+
+            CopyMemory(pCurrent, m_pOutputBuffer, codeSize);
+            pCurrent += alignedCodeSize;
+
+            if (m_nEH != 0)
+            {
+                IMAGE_COR_ILMETHOD_SECT_FAT *pEH = (IMAGE_COR_ILMETHOD_SECT_FAT *)pCurrent;
+                pEH->Kind = CorILMethod_Sect_EHTable | CorILMethod_Sect_FatFormat;
+                pEH->DataSize = (unsigned)(sizeof(IMAGE_COR_ILMETHOD_SECT_FAT) + sizeof(IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_FAT) * m_nEH);
+
+                pCurrent = (BYTE*)(pEH + 1);
+
+                for (unsigned iEH = 0; iEH < m_nEH; iEH++)
+                {
+                    EHClause *pSrc = &(m_pEH[iEH]);
+                    IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_FAT * pDst = (IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_FAT *)pCurrent;
+
+                    pDst->Flags = pSrc->m_Flags;
+                    pDst->TryOffset = pSrc->m_pTryBegin->m_offset;
+                    pDst->TryLength = pSrc->m_pTryEnd->m_offset - pSrc->m_pTryBegin->m_offset;
+                    pDst->HandlerOffset = pSrc->m_pHandlerBegin->m_offset;
+                    pDst->HandlerLength = pSrc->m_pHandlerEnd->m_pNext->m_offset - pSrc->m_pHandlerBegin->m_offset;
+                    if ((pSrc->m_Flags & COR_ILEXCEPTION_CLAUSE_FILTER) == 0)
+                        pDst->ClassToken = pSrc->m_ClassToken;
+                    else
+                        pDst->FilterOffset = pSrc->m_pFilter->m_offset;
+
+                    pCurrent = (BYTE*)(pDst + 1);
+                }
+            }
+        }
+
+        IfFailRet(SetILFunctionBody(totalSize, pBody));
+        DeallocateILMemory(pBody);
+
+        return S_OK;
+    }
+
+    HRESULT SetILFunctionBody(unsigned size, LPBYTE pBody)
+    {
+        if (m_pICorProfilerFunctionControl != NULL)
+        {
+            // We're supplying IL for a rejit, so use the rejit mechanism
+            IfFailRet(m_pICorProfilerFunctionControl->SetILFunctionBody(size, pBody));
+        }
+        else
+        {
+            // "classic-style" instrumentation on first JIT, so use old mechanism
+            IfFailRet(m_pICorProfilerInfo->SetILFunctionBody(m_moduleId, m_tkMethod, pBody));
+        }
+
+        return S_OK;
+    }
+
+    LPBYTE AllocateILMemory(unsigned size)
+    {
+        if (m_pICorProfilerFunctionControl != NULL)
+        {
+            // We're supplying IL for a rejit, so we can just allocate from
+            // the heap
+            return new BYTE[size];
+        }
+
+        // Else, this is "classic-style" instrumentation on first JIT, and
+        // need to use the CLR's IL allocator
+
+        if (FAILED(m_pICorProfilerInfo->GetILFunctionBodyAllocator(m_moduleId, &m_pIMethodMalloc)))
+            return NULL;
+
+        return (LPBYTE)m_pIMethodMalloc->Alloc(size);
+    }
+
+    void DeallocateILMemory(LPBYTE pBody)
+    {
+        if (m_pICorProfilerFunctionControl == NULL)
+        {
+            // Old-style instrumentation does not provide a way to free up bytes
+            return;
+        }
+
+        delete[] pBody;
+    }
+};
+
+HRESULT AddProbe(
+    ILRewriter * pilr,
+    FunctionID functionId,
+    UINT_PTR methodAddress,
+    ULONG32 methodSignature,
+    ILInstr * pInsertProbeBeforeThisInstr)
+{
+    ILInstr * pNewInstr = nullptr;
+
+    constexpr auto CEE_LDC_I = sizeof(size_t) == 8 ? CEE_LDC_I8 : sizeof(size_t) == 4 ? CEE_LDC_I4 : throw std::logic_error("size_t must be defined as 8 or 4");
+
+    pNewInstr = pilr->NewILInstr();
+    pNewInstr->m_opcode = CEE_LDC_I;
+    pNewInstr->m_Arg64 = functionId;
+    pilr->InsertBefore(pInsertProbeBeforeThisInstr, pNewInstr);
+
+    pNewInstr = pilr->NewILInstr();
+    pNewInstr->m_opcode = CEE_LDC_I;
+    pNewInstr->m_Arg64 = methodAddress;
+    pilr->InsertBefore(pInsertProbeBeforeThisInstr, pNewInstr);
+
+    pNewInstr = pilr->NewILInstr();
+    pNewInstr->m_opcode = CEE_CALLI;
+    pNewInstr->m_Arg32 = methodSignature;
+    pilr->InsertBefore(pInsertProbeBeforeThisInstr, pNewInstr);
+
+    return S_OK;
+}
+
+HRESULT AddEnterProbe(
+    ILRewriter * pilr,
+    FunctionID functionId,
+    UINT_PTR methodAddress,
+    ULONG32 methodSignature)
+{
+    ILInstr * pFirstOriginalInstr = pilr->GetILList()->m_pNext;
+
+    return AddProbe(pilr, functionId, methodAddress, methodSignature, pFirstOriginalInstr);
+}
+
+
+HRESULT AddExitProbe(
+    ILRewriter * pilr,
+    FunctionID functionId,
+    UINT_PTR methodAddress,
+    ULONG32 methodSignature)
+{
+    HRESULT hr;
+    BOOL fAtLeastOneProbeAdded = FALSE;
+
+    // Find all RETs, and insert a call to the exit probe before each one.
+    for (ILInstr * pInstr = pilr->GetILList()->m_pNext; pInstr != pilr->GetILList(); pInstr = pInstr->m_pNext)
+    {
+        switch (pInstr->m_opcode)
+        {
+        case CEE_RET:
+        {
+            // We want any branches or leaves that targeted the RET instruction to
+            // actually target the epilog instructions we're adding. So turn the "RET"
+            // into ["NOP", "RET"], and THEN add the epilog between the NOP & RET. That
+            // ensures that any branches that went to the RET will now go to the NOP and
+            // then execute our epilog.
+
+            // NOTE: The NOP is not strictly required, but is a simplification of the implementation.
+            // RET->NOP
+            pInstr->m_opcode = CEE_NOP;
+
+            // Add the new RET after
+            ILInstr * pNewRet = pilr->NewILInstr();
+            pNewRet->m_opcode = CEE_RET;
+            pilr->InsertAfter(pInstr, pNewRet);
+
+            // Add now insert the epilog before the new RET
+            hr = AddProbe(pilr, functionId, methodAddress, methodSignature, pNewRet);
+            if (FAILED(hr))
+                return hr;
+            fAtLeastOneProbeAdded = TRUE;
+
+            // Advance pInstr after all this gunk so the for loop continues properly
+            pInstr = pNewRet;
+            break;
+        }
+
+        default:
+            break;
+        }
+    }
+
+    if (!fAtLeastOneProbeAdded)
+        return E_FAIL;
+
+    return S_OK;
+}
+
+
+// Uses the general-purpose ILRewriter class to import original
+// IL, rewrite it, and send the result to the CLR
+HRESULT RewriteIL(
+    ICorProfilerInfo * pICorProfilerInfo,
+    ICorProfilerFunctionControl * pICorProfilerFunctionControl,
+    ModuleID moduleID,
+    mdMethodDef methodDef,
+    FunctionID functionId,
+    UINT_PTR enterMethodAddress,
+    UINT_PTR exitMethodAddress,
+
+    ULONG32 methodSignature)
+{
+    ILRewriter rewriter(pICorProfilerInfo, pICorProfilerFunctionControl, moduleID, methodDef);
+
+    IfFailRet(rewriter.Import());
+    {
+        // Adds enter/exit probes
+        IfFailRet(AddEnterProbe(&rewriter, functionId, enterMethodAddress, methodSignature));
+        IfFailRet(AddExitProbe(&rewriter, functionId, exitMethodAddress, methodSignature));
+    }
+    IfFailRet(rewriter.Export());
+
+    return S_OK;
+}

--- a/ProfilingAPI/ReJITEnterLeaveHooks/ILRewriter.h
+++ b/ProfilingAPI/ReJITEnterLeaveHooks/ILRewriter.h
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include "profiler_pal.h"
+
+HRESULT RewriteIL(
+    ICorProfilerInfo * pICorProfilerInfo,
+    ICorProfilerFunctionControl * pICorProfilerFunctionControl,
+    ModuleID moduleID,
+    mdMethodDef methodDef,
+    FunctionID functionId,
+    UINT_PTR enterMethodAddress,
+    UINT_PTR exitMethodAddress,
+    ULONG32 methodSignature);

--- a/ProfilingAPI/ReJITEnterLeaveHooks/LICENSE
+++ b/ProfilingAPI/ReJITEnterLeaveHooks/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 .NET Foundation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ProfilingAPI/ReJITEnterLeaveHooks/README.md
+++ b/ProfilingAPI/ReJITEnterLeaveHooks/README.md
@@ -1,0 +1,87 @@
+XPlat CoreCLR Profiler with ELT Simulation
+==========================================
+
+This sample shows a minimal CoreCLR profiler that simulates Enter/Leave hooks by rewriting the incoming MSIL and adding instructions to make P/Invoke calls to profiler supplied Enter/Leave functions.
+
+Prerequisites
+-------------
+
+* CoreCLR Repository (build from source) Dependencies
+* Clang 3.5  (Linux)
+* Visual Studio 2015 Community (Windows)
+
+Building on Linux, MacOSX
+-------------------------
+
+### Environment
+
+``build.sh`` expects the following environment variables to be setup; default values are shown below.
+
+```bash
+export CORECLR_PATH=~/coreclr # default
+export BuildOS=Linux # Linux(default), MacOSX
+export BuildArch=x64 # x64 (default)
+export BuildType=Debug # Debug(default), Release
+export Output=CorProfiler.so # default
+```
+
+``CORECLR_PATH`` is the path to your cloned and successfully built CoreCLR repository.
+
+``BuildOS``, ``BuildArch`` and ``BuildType`` must match how you built the CoreCLR repository, so the header files and other artifacts needed for compilation are found.
+
+### Build
+
+```bash
+git clone http://github.com/Microsoft/clr-samples
+cd clr-samples/profiling/eltprofiler
+./build.sh
+```
+
+### Setup
+
+```bash
+export CORECLR_PROFILER={cf0d821e-299b-5307-a3d8-b283c03916dd}
+export CORECLR_ENABLE_PROFILING=1
+export CORECLR_PROFILER_PATH=/filePath/to/CorProfiler.so
+./corerun YourProgram.dll
+```
+
+Building on Windows
+-------------------
+
+### Environment
+
+All instructions must be run on the ``Visual Studio Developer Command Prompt (x64)``.
+
+```batch
+SET CORECLR_PATH=../coreclr # default
+SET BuildOS=Windows # Windows(default)
+SET BuildArch=x64 # x64 (default)
+SET BuildType=Debug # Debug(default), Release
+SET Output=CorProfiler.dll # default
+```
+
+### Build
+
+* msbuild
+* or open using Visual Studio 2015 Community and Build
+
+### Setup
+
+```batch
+SET CORECLR_PROFILER={cf0d821e-299b-5307-a3d8-b283c03916dd}
+SET CORECLR_ENABLE_PROFILING=1
+SET CORECLR_PROFILER_PATH=C:\filePath\to\CorProfiler.dll
+corerun YourProgram.dll
+```
+
+### Setup (on .NET 4.6.1+ CLR)
+
+This profiler is also capable of running on the .NET 4.6.1 (or higher) CLR.
+
+```batch
+SET COR_PROFILER={cf0d821e-299b-5307-a3d8-b283c03916dd}
+SET COR_ENABLE_PROFILING=1
+SET COR_PROFILER_PATH=C:\filePath\to\CorProfiler.dll
+YourProgram.exe
+```

--- a/ProfilingAPI/ReJITEnterLeaveHooks/build.cmd
+++ b/ProfilingAPI/ReJITEnterLeaveHooks/build.cmd
@@ -1,0 +1,1 @@
+msbuild /p:Configuration="Release" /p:BuildOS="Windows_NT" /p:BuildType="Release" /p:BuildArch="x64" /p:CORECLR_PATH="..\coreclr"

--- a/ProfilingAPI/ReJITEnterLeaveHooks/build.sh
+++ b/ProfilingAPI/ReJITEnterLeaveHooks/build.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+[ -z "${CORECLR_PATH:-}" ] && CORECLR_PATH=~/coreclr
+[ -z "${BuildOS:-}"      ] && BuildOS=Linux
+[ -z "${BuildArch:-}"    ] && BuildArch=x64
+[ -z "${BuildType:-}"    ] && BuildType=Debug
+[ -z "${Output:-}"       ] && Output=CorProfiler.so
+
+printf '  CORECLR_PATH : %s\n' "$CORECLR_PATH"
+printf '  BuildOS      : %s\n' "$BuildOS"
+printf '  BuildArch    : %s\n' "$BuildArch"
+printf '  BuildType    : %s\n' "$BuildType"
+
+printf '  Building %s ... ' "$Output"
+
+CXX_FLAGS="$CXX_FLAGS --no-undefined -Wno-invalid-noreturn -fPIC -fms-extensions -DBIT64 -DPAL_STDCPP_COMPAT -DPLATFORM_UNIX -std=c++11"
+INCLUDES="-I $CORECLR_PATH/src/pal/inc/rt -I $CORECLR_PATH/src/pal/prebuilt/inc -I $CORECLR_PATH/src/pal/inc -I $CORECLR_PATH/src/inc -I $CORECLR_PATH/bin/Product/$BuildOS.$BuildArch.$BuildType/inc"
+
+clang++ -shared -o $Output $CXX_FLAGS $INCLUDES ClassFactory.cpp CorProfiler.cpp dllmain.cpp ILRewriter.cpp
+
+printf 'Done.\n'

--- a/ProfilingAPI/ReJITEnterLeaveHooks/dllmain.cpp
+++ b/ProfilingAPI/ReJITEnterLeaveHooks/dllmain.cpp
@@ -1,0 +1,37 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include "ClassFactory.h"
+
+const IID IID_IUnknown      = { 0x00000000, 0x0000, 0x0000, { 0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46 } };
+
+const IID IID_IClassFactory = { 0x00000001, 0x0000, 0x0000, { 0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46 } };
+
+BOOL STDMETHODCALLTYPE DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
+{
+    return TRUE;
+}
+
+extern "C" HRESULT STDMETHODCALLTYPE DllGetClassObject(REFCLSID rclsid, REFIID riid, LPVOID* ppv)
+{
+    // {cf0d821e-299b-5307-a3d8-b283c03916dd}
+    const GUID CLSID_CorProfiler = { 0xcf0d821e, 0x299b, 0x5307, { 0xa3, 0xd8, 0xb2, 0x83, 0xc0, 0x39, 0x16, 0xdd } };
+
+    if (ppv == nullptr || rclsid != CLSID_CorProfiler)
+    {
+        return E_FAIL;
+    }
+
+    auto factory = new ClassFactory;
+    if (factory == nullptr)
+    {
+        return E_FAIL;
+    }
+
+    return factory->QueryInterface(riid, ppv);
+}
+
+extern "C" HRESULT STDMETHODCALLTYPE DllCanUnloadNow()
+{
+    return S_OK;
+}

--- a/ProfilingAPI/ReJITEnterLeaveHooks/profiler_pal.h
+++ b/ProfilingAPI/ReJITEnterLeaveHooks/profiler_pal.h
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma once
+
+#ifndef WIN32
+#include <cstdlib>
+#include "pal_mstypes.h"
+#include "pal.h"
+#include "ntimage.h"
+#include "corhdr.h"
+
+#define CoTaskMemAlloc(cb) malloc(cb)
+#define CoTaskMemFree(cb) free(cb)
+
+#endif
+
+#include <string>


### PR DESCRIPTION
CoreCLR XPlat Profiler that simulates Enter/Leave hooks by rewriting the incoming MSIL.

I personally feel we should deprecate the ELT hooks in general, it's another stub code path with different behavior (and significantly less testing by definition). Furthermore, every new bring-up of a target or platform will need testing and possibly tweaking.
