### PR TITLE
Add missing opcodes to k_rgnStackPushes

### DIFF
--- a/ProfilingAPI/ReJITEnterLeaveHooks/ILRewriter.cpp
+++ b/ProfilingAPI/ReJITEnterLeaveHooks/ILRewriter.cpp
@@ -133,6 +133,8 @@ static int k_rgnStackPushes[] = {
 #undef PushRef 
 #undef VarPush 
 #undef OPDEF
+    0,  // CEE_COUNT
+    0   // CEE_SWITCH_ARG
 };
 
 class ILRewriter


### PR DESCRIPTION
The rewriter defined two extra opcodes, CEE_COUNT and CEE_SWITCH_ARG, but does not define them in the `k_rgnStackPushes` array. This can cause out-of-bounds reads when computing the value of maxstack.